### PR TITLE
Fix pytest workflow (again)

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.10" ]
+        python-version: [ "3.10-dev" ]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
(Potentially) Fix pytest forkflow by changing python version from `3.10` to `3.10-dev`